### PR TITLE
Update ADMINISTRATOR.md

### DIFF
--- a/ADMINISTRATOR.md
+++ b/ADMINISTRATOR.md
@@ -59,7 +59,7 @@ The following is an example of how the added line appears in the JSON file. Do n
          "path": "/usr/bin/nvidia-container-runtime",
          "runtimeArgs": []
      }
- },
+ }
 }
 ```
 Reboot the system and try the following command. 


### PR DESCRIPTION
with "," at the end, it produced
'ERRO[0000] unable to load config: invalid character '}' looking for beginning of object key string' error when executing 'sudo nvidia-ctk runtime configure --runtime=docker' in my case.